### PR TITLE
added colorFormat output option + tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,11 @@ function CssColorExtractor() {
                 return;
             }
 
-            colors.push(value);
+            if (typeof color[options.colorFormat] === 'function') {
+                colors.push(color[options.colorFormat].call(color, value));
+            } else {
+                colors.push(value);
+            }
         });
 
         return unique(colors);

--- a/test/test.js
+++ b/test/test.js
@@ -517,4 +517,49 @@ describe('postcss-colors-only', function () {
             done
         );
     });
+
+    it('should output rgbString format', function (done) {
+        test(
+            'a { color: #123123; }',
+            ['rgb(18, 49, 35)'],
+            { colorFormat: 'rgbString' },
+            done
+        );
+    });
+
+    it('should output hslString format', function (done) {
+        test(
+            'a { color: #123123; }',
+            ['hsl(153, 46%, 13%)'],
+            { colorFormat: 'hslString' },
+            done
+        );
+    });
+
+    it('should output percentString format', function (done) {
+        test(
+            'a { color: #123123; }',
+            ['rgb(7%, 19%, 14%)'],
+            { colorFormat: 'percentString' },
+            done
+        );
+    });
+
+    it('should output hexString format', function (done) {
+        test(
+            'a { color: rgb(255, 255, 255); }',
+            ['#FFFFFF'],
+            { colorFormat: 'hexString' },
+            done
+        );
+    });
+
+    it('should output keyword format', function (done) {
+        test(
+            'a { color: rgb(255, 255, 255); }',
+            ['white'],
+            { colorFormat: 'keyword' },
+            done
+        );
+    });
 });


### PR DESCRIPTION
Added option to specify the output format using the available color module strings: https://www.npmjs.com/package/color#css-strings
