### PR TITLE
Add options to return all colors instead of unique colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ var options = {
   withoutGrey: false, // set to true to remove rules that only have grey colors
   withoutMonochrome: false, // set to true to remove rules that only have grey, black, or white colors
   colorFormat: null // transform colors to one of the following formats: hexString, rgbString, percentString, hslString, hwbString, or keyword
+  allColors: false // set to true to get all colors instead of unique colors
 };
 
 // extract from a full stylesheet

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ function CssColorExtractor() {
         options = util._extend({
             withoutGrey:       false,
             withoutMonochrome: false,
+            allColors:         false,
             colorFormat:       null
         }, options);
 
@@ -118,7 +119,7 @@ function CssColorExtractor() {
             }
         });
 
-        return unique(colors);
+        return options.allColors ? colors : unique(colors);
     }
 
     function extractColorsFromDecl(decl, options) {
@@ -135,6 +136,10 @@ function CssColorExtractor() {
         postcss.parse(css).walkDecls(function (decl) {
             colors = colors.concat(extractColorsFromDecl(decl, options));
         });
+
+        if (options && options.allColors) {
+            return colors;
+        }
 
         return unique(colors);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -580,4 +580,34 @@ describe('postcss-colors-only', function () {
             done
         );
     });
+
+    it('should return unique colors', function (done) {
+        test(
+            'a { color: #123123; } p { color: #123123; } ' +
+                'button { background-color: #fff; }',
+            ['#123123', '#fff'],
+            {},
+            done
+        );
+    });
+
+    it('should return unique colors without options', function (done) {
+        test(
+            'a { color: #123123; } p { color: #123123; } ' +
+                'button { background-color: #fff; }',
+            ['#123123', '#fff'],
+            null,
+            done
+        );
+    });
+
+    it('should return all colors', function (done) {
+        test(
+            'a { color: #123123; } p { color: #123123; } ' +
+                'button { background-color: #fff; }',
+            ['#123123', '#123123', '#fff'],
+            { allColors: true },
+            done
+        );
+    });
 });


### PR DESCRIPTION
Add an option to return all colors, which can be used to analyze the duplicated colors used in the stylesheet.